### PR TITLE
Bugfix: Mistake on Function Call

### DIFF
--- a/pgmm_decrypt/_twofish.pyi
+++ b/pgmm_decrypt/_twofish.pyi
@@ -2,7 +2,7 @@ def prepare_key(key: bytes):
     """
     Prepare the Twofish key.
 
-    Key Mmst be between 1 and 32 bytes.
+    Key must be between 0 and 32 bytes.
     """
     ...
 

--- a/pgmm_decrypt/decrypt.py
+++ b/pgmm_decrypt/decrypt.py
@@ -1,13 +1,16 @@
 from typing import Callable, Generator
 
-from .utils import xor_block
+from .utils import pad, xor_block
 
 
 def derive_subkey(key: bytes, plaintext_len: int) -> bytes:
+    if len(key) < 8:    # make sure `key` is long enough
+        key = pad(key, 8)
+
     ptl_bytes = plaintext_len.to_bytes(8, "little").rstrip(b"\0")   # 8 bytes for length value should be enough
     xor_key = xor_block(ptl_bytes, key).replace(b"\0", b"\1")   # this stops at the end of the shorter one
 
-    return xor_key + key[len(xor_key):] # append the rest unchanged bytes, assume `key` is alwalys longer
+    return xor_key + key[len(xor_key):] # append the rest unchanged bytes
 
 
 def cbc_decrypt_wrapper(block_decrypt_func: Callable[[bytes], bytes], iv: bytes) -> Callable[[bytes], bytes]:

--- a/pgmm_decrypt/pgmm.py
+++ b/pgmm_decrypt/pgmm.py
@@ -1,7 +1,6 @@
-from .twofish import Twofish
 from .decrypt import cbc_decrypt_wrapper, decrypt, derive_subkey
+from .twofish import Twofish
 from .weakfish import Weakfish
-from .utils import pad
 
 PGMM_IV = bytes.fromhex("A047E93D230A4C62A744B1A4EE857FBA")
 
@@ -23,10 +22,6 @@ def decrypt_pgmm_resource(
         return file_bytes
 
     is_weakfish = decrypted_key is None or len(decrypted_key) <= 8
-
-    if not decrypted_key is None:
-        decrypted_key = pad(decrypted_key)
-
     pt_len = len(file_bytes) - 4 - file_bytes[3]
 
     cipher = (


### PR DESCRIPTION
There was a **mistake** in your code:

```py
def decrypt_pgmm_resource(...):
    ...
    if not decrypted_key is None:
        decrypted_key = pad(decrypted_key)    # ERROR: missing argument for `block_size`
    ...
```

I fixed it. **Furthermore**, I moved this padding process into `derive_subkey()` because its only purpose is to ensure the key is long enough to derive a subkey. That is why I wrote this part initially. So now, I put it into `derive_subkey()` to clear up the confusion.
